### PR TITLE
Put performance profiling for bidiff in optional feature

### DIFF
--- a/crates/bidiff/Cargo.toml
+++ b/crates/bidiff/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2018"
 repository = "https://github.com/divvun/bidiff"
 
 [features]
-default = ["enc"]
+default = ["enc", "profiling"]
 enc = ["byteorder", "integer-encoding"]
 instructions = []
+profiling = []
 
 [dependencies]
 # for enc

--- a/crates/bidiff/Cargo.toml
+++ b/crates/bidiff/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 repository = "https://github.com/divvun/bidiff"
 
 [features]
-default = ["enc", "profiling"]
+default = ["enc"]
 enc = ["byteorder", "integer-encoding"]
 instructions = []
 profiling = []


### PR DESCRIPTION
Fixes #11 by allowing wasm32 users to disable all usage of std::time. Should also help in cases where the overhead of collecting time is not wanted. Tests pass with and without the profiling feature, and I can confirm that bidiff is working in a wasm-pack project, and bipatch is working on a Kobo Libra 2 (arm-unknown-linux-gnueabihf)